### PR TITLE
Add test: weigthed_average_invalid_column

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -14,3 +14,21 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_weigthed_average_invalid_column():
+    import pandas as pd
+
+    from src.data.data_processing import weigthed_average
+
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    weights = {"A": 0.4, "C": 0.6}  # 'C' does not exist in df
+
+    try:
+        weigthed_average(df, weights)
+    except KeyError:
+        pass
+    else:
+        assert (
+            False
+        ), "Expected KeyError when weights reference non-existent DataFrame columns"


### PR DESCRIPTION
## Test Addition

**Test Name:** weigthed_average_invalid_column
**Description:** Test weigthed_average raises error or handles case when weights reference non-existent DataFrame columns.
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
