### PR TITLE
Add test: groupweightedaverage_nan_and_non_numeric_values

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -14,3 +14,31 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_groupweightedaverage_nan_and_non_numeric_values():
+    import numpy as np
+    import pandas as pd
+
+    from src.data.data_processing import groupweightedaverage
+
+    # Data with NaN in value and non-numeric in weights
+    df_nan_value = pd.DataFrame(
+        {"brand": ["A", "A", "B"], "value": [1.0, np.nan, 3.0], "wt": [1.0, 2.0, 3.0]}
+    )
+    df_non_numeric_weights = pd.DataFrame(
+        {"brand": ["A", "A", "B"], "value": [1.0, 2.0, 3.0], "wt": [1.0, "two", 3.0]}
+    )
+
+    # With NaN values, result should propagate NaN for group "A"
+    result_nan = groupweightedaverage(
+        df_nan_value, groupby="brand", value="value", weights="wt"
+    )
+    assert pd.isna(result_nan.loc["A"])
+    assert not pd.isna(result_nan.loc["B"])
+
+    # Non-numeric weights should raise an error
+    with pytest.raises(TypeError):
+        groupweightedaverage(
+            df_non_numeric_weights, groupby="brand", value="value", weights="wt"
+        )


### PR DESCRIPTION
## Test Addition

**Test Name:** groupweightedaverage_nan_and_non_numeric_values
**Description:** Test groupweightedaverage with NaN and non-numeric values in value or weights columns to verify error raising or propagation.
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
