### PR TITLE
Add test: weigthed_average_non_numeric_column

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import pytest
+
+from src.data.data_processing import weigthed_average
+
+
+def test_weigthed_average_non_numeric_column():
+    df = pd.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": ["x", "y", "z"],  # non-numeric column
+        }
+    )
+    weights = {"A": 1.0, "B": 1.0}
+    with pytest.raises(TypeError):
+        _ = weigthed_average(df, weights)


### PR DESCRIPTION
## Test Addition

**Test Name:** weigthed_average_non_numeric_column
**Description:** Test weigthed_average raises an error or rejects input if weighted columns contain non-numeric data.
**Type:** unit
**File:** tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
