### PR TITLE
Add test: weigthed_average-non_numeric_data

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -14,3 +14,13 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_weigthed_average_non_numeric_data():
+    df = pd.DataFrame(
+        {"A": [1, 2, 3], "B": ["a", "b", "c"], "C": [4, 5, 6]}  # non-numeric column
+    )
+    weights = {"A": 0.3, "B": 0.3, "C": 0.4}
+
+    with pytest.raises(TypeError):
+        weigthed_average(df, weights)


### PR DESCRIPTION
## Test Addition

**Test Name:** weigthed_average-non_numeric_data
**Description:** Test that weigthed_average raises error or handles columns containing non-numeric data
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
