### PR TITLE
Add test: groupweightedaverage-zero_total_weight

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -14,3 +14,20 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_groupweightedaverage_zero_total_weight():
+    # Create a DataFrame where weights sum to zero for each group
+    df = pd.DataFrame(
+        {
+            "group": ["x", "x", "y", "y"],
+            "value": [10, 20, 30, 40],
+            "weight": [0, 0, 0, 0],
+        }
+    )
+
+    result = groupweightedaverage(df, groupby="group", value="value", weights="weight")
+
+    # Expect the result to contain NaN for both groups because denominator is zero
+    assert result.index.tolist() == ["x", "y"]
+    assert result.isna().all()


### PR DESCRIPTION
## Test Addition

**Test Name:** groupweightedaverage-zero_total_weight
**Description:** Test groupweightedaverage behavior when the sum of weights per group is zero to avoid division by zero
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
