### PR TITLE
Add test: groupweightedaverage-zero-sum-weights

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+
 from src.data.data_processing import weigthed_average
 
 
@@ -14,3 +15,23 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_groupweightedaverage_zero_sum_weights():
+    # Create a DataFrame where weights sum to zero within each group
+    df = pd.DataFrame(
+        {
+            "group": ["x", "x", "y", "y"],
+            "value": [1.0, 2.0, 3.0, 4.0],
+            "weights": [1.0, -1.0, 0.0, 0.0],
+        }
+    )
+
+    result = groupweightedaverage(df, groupby="group", value="value", weights="weights")
+
+    # sum of weights in group 'x' = 0 and group 'y' = 0
+    # Expect result to be inf, -inf or NaN; usually division by zero leads to NaN or +/-inf in numpy
+    # Check the results for NaN or infinite values, i.e. no exceptions raised
+    assert all(
+        np.isnan(x) or np.isinf(x) for x in result
+    ), "Expected NaN or infinite values when sum of weights per group is zero"


### PR DESCRIPTION
## Test Addition

**Test Name:** groupweightedaverage-zero-sum-weights
**Description:** Test groupweightedaverage behavior when sum of weights per group is zero, checking for divide by zero or NaN propagation.
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
