### PR TITLE
Add test: groupweightedaverage-non_numeric_input

### DIFF
--- a/src/data/tests/test_data.py
+++ b/src/data/tests/test_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+
 from src.data.data_processing import weigthed_average
 
 
@@ -14,3 +15,17 @@ def test_weigthed_average():
     result = weigthed_average(df, weights)
     expected = pd.Series([2.0, 0.0, 0.0])
     assert np.allclose(result, expected), f"Expected {expected}, but got {result}"
+
+
+def test_groupweightedaverage_non_numeric_input():
+    df = pd.DataFrame(
+        {
+            "group": ["A", "A", "B"],
+            "value": [1.0, "non-numeric", 3.0],
+            "weight": [1.0, 2.0, "non-numeric"],
+        }
+    )
+
+    # Expect a TypeError or ValueError due to invalid operations on non-numeric data
+    with pytest.raises((TypeError, ValueError)):
+        groupweightedaverage(df, groupby="group", value="value", weights="weight")


### PR DESCRIPTION
## Test Addition

**Test Name:** groupweightedaverage-non_numeric_input
**Description:** Test groupweightedaverage to ensure errors are raised or handled when weights or values columns contain non-numeric data.
**Type:** unit
**File:** src/data/tests/test_data.py

This PR adds a new test case as suggested by the automated test analysis.
